### PR TITLE
Allowed specifying integration/end-to-end tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,3 +255,11 @@ gulp
 
 To build, run `gulp`.
 You can build without running tests using `gulp build`, or just run tests using `gulp test`.
+
+### Tests
+
+Integration and end-to-end tests are done using BDD.
+Folders under `/test/integration` and `/test/end-to-end` will contain a `.gls` file with GLS source code along with text files of the expected output in supported languages.
+These are verifified during `gulp test`.
+
+You can run specific tests using their gulp task (`gulp test:integration` or `gulp test:end-to-end`), and individual test groups using `--command` (`gulp test:end-to-end --command arrays`).

--- a/test/ArgvParser.js
+++ b/test/ArgvParser.js
@@ -1,0 +1,36 @@
+const ArgvParser = (function () {
+    "use strict";
+
+    /**
+     * Parsers test names from argv.
+     */
+    class ArgvParser {
+        /**
+         * Initializes a new instance of the ArgvParser class.
+         * 
+         * @param {string[]} argv   Arguments from process.argv.
+         */
+        constructor(argv) {
+            this.argv = argv;
+        }
+
+        /**
+         * @returns {Set} Test names from argv.
+         */
+        parseCommandNames() {
+            const testNames = new Set();
+
+            for (let i = 0; i < this.argv.length - 1; i += 1) {
+                if (this.argv[i] === "--command") {
+                    testNames.add(this.argv[i + 1].toLowerCase());
+                }
+            }
+
+            return testNames;
+        }
+    }
+
+    return ArgvParser;
+})();
+
+module.exports = ArgvParser;

--- a/test/ComparisonTestsRunner.js
+++ b/test/ComparisonTestsRunner.js
@@ -81,8 +81,8 @@ const ComparisonTestsRunner = (function () {
          * @private
          */
         readTestsUnderPath(rootPath, commandsToRun) {
+            const tests = {};
             let children = fs.readdirSync(rootPath);
-            let tests = {};
 
             if (commandsToRun) {
                 children = children.filter(child => {

--- a/test/ComparisonTestsRunner.js
+++ b/test/ComparisonTestsRunner.js
@@ -1,4 +1,4 @@
-var ComparisonTestsRunner = (function () {
+const ComparisonTestsRunner = (function () {
     "use strict";
 
     const expect = require("chai").expect;
@@ -15,11 +15,13 @@ var ComparisonTestsRunner = (function () {
          * Initializes a new instance of the ComparisonTestsRunner class.
          * 
          * @param {string} section   A directory path to read tests under.
+         * @param {Set} commandsToRun   Command groups to run, if not all.
          */
-        constructor(section) {
+        constructor(section, commandsToRun) {
             this.section = section;
+            this.commandsToRun = commandsToRun;
             this.rootPath = path.resolve(section);
-            this.commandTests = this.readTestsUnderPath(this.rootPath);
+            this.commandTests = this.readTestsUnderPath(this.rootPath, this.commandsToRun);
             this.languagesBag = new LanguagesBag();
         }
 
@@ -73,13 +75,20 @@ var ComparisonTestsRunner = (function () {
         /**
          * Retrieves, for each command in a directory, tests under that command.
          * 
-         * @param rootPath   An absolute path to a command's tests folder.
-         * @returns Tests for each command in a directory.
+         * @param {string} rootPath   An absolute path to a command's tests folder.
+         * @param {Set} commandsToRun   Command groups to run, if not all.
+         * @returns {object}   Tests for each command in a directory.
          * @private
          */
-        readTestsUnderPath(rootPath) {
-            const children = fs.readdirSync(rootPath);
+        readTestsUnderPath(rootPath, commandsToRun) {
+            let children = fs.readdirSync(rootPath);
             let tests = {};
+
+            if (commandsToRun) {
+                children = children.filter(child => {
+                    return commandsToRun.has(child.toLowerCase());
+                });
+            }
 
             children.forEach(childName => {
                 tests[childName] = fs.readdirSync(path.resolve(rootPath, childName))
@@ -91,8 +100,11 @@ var ComparisonTestsRunner = (function () {
         }
         
         /**
+         * Reads the code contents of a test file.
          * 
-         * 
+         * @param {string} command   The command this file is under.
+         * @param {string} name   The name of the file.
+         * @returns {string[]}   Lines of code in the file.
          * @private
          */
         readCommandFile(command, name) {

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -1,4 +1,6 @@
-var ComparisonTestsRunner = require("./ComparisonTestsRunner.js");
+const ArgvParser = require("./ArgvParser");
+const ComparisonTestsRunner = require("./ComparisonTestsRunner");
 
-var integrationTests = new ComparisonTestsRunner("test/end-to-end");
+const testNames = new ArgvParser(process.argv).parseCommandNames();
+const integrationTests = new ComparisonTestsRunner("test/end-to-end", testNames);
 integrationTests.run();

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,4 +1,6 @@
-var ComparisonTestsRunner = require("./ComparisonTestsRunner.js");
+const ArgvParser = require("./ArgvParser");
+const ComparisonTestsRunner = require("./ComparisonTestsRunner");
 
-var integrationTests = new ComparisonTestsRunner("test/integration");
+const testNames = new ArgvParser(process.argv).parseCommandNames();
+const integrationTests = new ComparisonTestsRunner("test/integration", testNames);
 integrationTests.run();


### PR DESCRIPTION
`gulp test:end-to-end --command Arrays`

No more waiting for all tests to finish and piping output to a text file
because the CMD window isn't big enough.

Fixes #100.