### PR TITLE
add support for new object instantiation

### DIFF
--- a/src/Commands/CommandNames.ts
+++ b/src/Commands/CommandNames.ts
@@ -358,9 +358,9 @@ export class CommandNames {
     public static MemberVariableDeclare: string = "member variable declare";
 
     /**
-     * Name key for the Not command.
+     * Name key for the New command.
      */
-    public static NewObject: string = "new object";
+    public static NewObject: string = "new";
 
     /**
      * Name key for the Not command.

--- a/src/Commands/CommandNames.ts
+++ b/src/Commands/CommandNames.ts
@@ -360,6 +360,11 @@ export class CommandNames {
     /**
      * Name key for the Not command.
      */
+    public static NewObject: string = "new object";
+
+    /**
+     * Name key for the Not command.
+     */
     public static Not: string = "not";
 
     /**

--- a/src/Commands/CommandsBag.ts
+++ b/src/Commands/CommandsBag.ts
@@ -73,6 +73,7 @@ import { MathMaxCommand } from "./MathMaxCommand";
 import { MathMinCommand } from "./MathMinCommand";
 import { MemberVariableCommand } from "./MemberVariableCommand";
 import { MemberVariableDeclareCommand } from "./MemberVariableDeclareCommand";
+import { NewCommand } from "./NewCommand";
 import { NotCommand } from "./NotCommand";
 import { OperationCommand } from "./OperationCommand";
 import { OperatorCommand } from "./OperatorCommand";
@@ -183,6 +184,7 @@ export class CommandsBag {
             [CommandNames.MathMin]: new MathMinCommand(context),
             [CommandNames.MemberVariable]: new MemberVariableCommand(context),
             [CommandNames.MemberVariableDeclare]: new MemberVariableDeclareCommand(context),
+            [CommandNames.NewObject]: new NewCommand(context),
             [CommandNames.Not]: new NotCommand(context),
             [CommandNames.Operation]: new OperationCommand(context),
             [CommandNames.Operator]: new OperatorCommand(context),

--- a/src/Commands/NewCommand.ts
+++ b/src/Commands/NewCommand.ts
@@ -1,0 +1,100 @@
+import { ConversionContext } from "../Conversions/ConversionContext";
+import { Import } from "../Languages/Imports/Import";
+import { NewProperties, NewInstantiationSyntaxKind } from "../Languages/Properties/NewProperties";
+import { Command } from "./Command";
+import { LineResults } from "./LineResults";
+import { Parameter } from "./Parameters/Parameter";
+import { RepeatingParameters } from "./Parameters/RepeatingParameters";
+import { SingleParameter } from "./Parameters/SingleParameter";
+
+/**
+ * A command for instantiating an object of a given type.
+ */
+export class NewCommand extends Command {
+    /**
+     * Metadata on what object to instantiate.
+     */
+    protected newProperties: NewProperties;
+
+    /**
+     * Information on parameters this command takes in.
+     */
+    private static parameters: Parameter[] = [
+        new SingleParameter("typeName", "The type of the object to instantiate.", true),
+        new RepeatingParameters(
+            "Arguments to pass into the constructor",
+            [
+                new SingleParameter("argument", "Argument to pass into the constructor", false)
+            ])
+    ];
+
+    /**
+     * @returns Information on parameters this command takes in.
+     */
+    public getParameters(): Parameter[] {
+        return NewCommand.parameters;
+    }
+
+    /**
+     * Initializes a new instance of the Command class.
+     * 
+     * @param context   The driving context for converting the command.
+     */
+    constructor(context: ConversionContext) {
+        super(context);
+
+        this.newProperties = this.language.properties.newProp;
+    }
+
+    /**
+     * Renders the command for a language with the given parameters.
+     * 
+     * @param parameters   The command's name, followed by any number of
+     *                     items to initialize in the Array.
+     * @returns Line(s) of code in the language.
+     */
+    public render(parameters: string[]): LineResults {
+        let result: string = "";
+
+        // the parser ensures we have a class name here in the argument list
+        let typeName: string = parameters[1];
+
+        if (this.newProperties.instantiationKind === NewInstantiationSyntaxKind.Prefix) {
+            result += this.newProperties.keyword;
+            result += " ";
+            result += typeName;
+            result += "(";
+            if (parameters.length > 2) {
+                result += parameters[2];
+                for (let i: number = 3; i < parameters.length; i += 1) {
+                    result += ", " + parameters[i];
+                }
+            }
+            result += ")";
+        } else if (this.newProperties.instantiationKind === NewInstantiationSyntaxKind.MemberMethodCall) {
+            result += typeName;
+            result += ".";
+            result += this.newProperties.keyword;
+            result += "(";
+            if (parameters.length > 2) {
+                result += parameters[2];
+                for (let i: number = 3; i < parameters.length; i += 1) {
+                    result += ", " + parameters[i];
+                }
+            }
+            result += ")";
+        } else { // NewInstantiationSyntaxType.MethodCall
+            result += typeName;
+            result += "(";
+            if (parameters.length > 2) {
+                result += parameters[2];
+                for (let i: number = 3; i < parameters.length; i += 1) {
+                    result += ", " + parameters[i];
+                }
+            }
+            result += ")";
+        }
+
+        return LineResults.newSingleLine(result, false);
+    }
+}

--- a/src/Languages/CSharp.ts
+++ b/src/Languages/CSharp.ts
@@ -21,6 +21,7 @@ import { ListProperties } from "./Properties/ListProperties";
 import { LoopProperties } from "./Properties/LoopProperties";
 import { MathProperties } from "./Properties/MathProperties";
 import { NativeCallProperties, NativeCallScope, NativeCallType } from "./Properties/NativeCallProperties";
+import { NewProperties, NewInstantiationSyntaxKind } from "./Properties/NewProperties";
 import { NumberProperties } from "./Properties/NumberProperties";
 import { OutputProperties } from "./Properties/OutputProperties";
 import { ParameterProperties } from "./Properties/ParameterProperties";
@@ -375,6 +376,16 @@ export class CSharp extends CLikeLanguage {
                 ImportRelativity.Absolute)
         ];
         math.mathName = "Math";
+    }
+
+    /**
+     * Generates metadata on new object instantiation.
+     * 
+     * @param numbers   A property container for metadata on numbers.
+     */
+    protected generateNewProperties(newProp: NewProperties): void {
+        newProp.instantiationKind = NewInstantiationSyntaxKind.Prefix;
+        newProp.keyword = "new";
     }
 
     /**

--- a/src/Languages/CSharp.ts
+++ b/src/Languages/CSharp.ts
@@ -381,7 +381,7 @@ export class CSharp extends CLikeLanguage {
     /**
      * Generates metadata on new object instantiation.
      * 
-     * @param numbers   A property container for metadata on numbers.
+     * @param newProp   A property container for metadata on new object instantiation.
      */
     protected generateNewProperties(newProp: NewProperties): void {
         newProp.instantiationKind = NewInstantiationSyntaxKind.Prefix;

--- a/src/Languages/Java.ts
+++ b/src/Languages/Java.ts
@@ -21,6 +21,7 @@ import { ListProperties } from "./Properties/ListProperties";
 import { LoopProperties } from "./Properties/LoopProperties";
 import { MathProperties } from "./Properties/MathProperties";
 import { NativeCallProperties, NativeCallScope, NativeCallType } from "./Properties/NativeCallProperties";
+import { NewProperties, NewInstantiationSyntaxKind } from "./Properties/NewProperties";
 import { NumberProperties } from "./Properties/NumberProperties";
 import { OutputProperties } from "./Properties/OutputProperties";
 import { ParameterProperties } from "./Properties/ParameterProperties";
@@ -372,6 +373,16 @@ export class Java extends CLikeLanguage {
             NativeCallType.Function);
         math.requiredImports = [];
         math.mathName = "Math";
+    }
+
+    /**
+     * Generates metadata on new object instantiation.
+     * 
+     * @param numbers   A property container for metadata on numbers.
+     */
+    protected generateNewProperties(newProp: NewProperties): void {
+        newProp.instantiationKind = NewInstantiationSyntaxKind.Prefix;
+        newProp.keyword = "new";
     }
 
     /**

--- a/src/Languages/Java.ts
+++ b/src/Languages/Java.ts
@@ -378,7 +378,7 @@ export class Java extends CLikeLanguage {
     /**
      * Generates metadata on new object instantiation.
      * 
-     * @param numbers   A property container for metadata on numbers.
+     * @param newProp   A property container for metadata on new object instantiation.
      */
     protected generateNewProperties(newProp: NewProperties): void {
         newProp.instantiationKind = NewInstantiationSyntaxKind.Prefix;

--- a/src/Languages/JavaScript.ts
+++ b/src/Languages/JavaScript.ts
@@ -338,7 +338,7 @@ export class JavaScript extends CLikeLanguage {
     /**
      * Generates metadata on new object instantiation.
      * 
-     * @param numbers   A property container for metadata on numbers.
+     * @param newProp   A property container for metadata on new object instantiation.
      */
     protected generateNewProperties(newProp: NewProperties): void {
         newProp.instantiationKind = NewInstantiationSyntaxKind.Prefix;

--- a/src/Languages/JavaScript.ts
+++ b/src/Languages/JavaScript.ts
@@ -20,6 +20,7 @@ import { LoopProperties } from "./Properties/LoopProperties";
 import { MathProperties } from "./Properties/MathProperties";
 import { NativeCallProperties, NativeCallScope, NativeCallType } from "./Properties/NativeCallProperties";
 import { NumberProperties } from "./Properties/NumberProperties";
+import { NewProperties, NewInstantiationSyntaxKind } from "./Properties/NewProperties";
 import { OperatorProperties } from "./Properties/OperatorProperties";
 import { OutputProperties } from "./Properties/OutputProperties";
 import { ParameterProperties } from "./Properties/ParameterProperties";
@@ -332,6 +333,16 @@ export class JavaScript extends CLikeLanguage {
             NativeCallType.Function);
         math.requiredImports = [];
         math.mathName = "Math";
+    }
+
+    /**
+     * Generates metadata on new object instantiation.
+     * 
+     * @param numbers   A property container for metadata on numbers.
+     */
+    protected generateNewProperties(newProp: NewProperties): void {
+        newProp.instantiationKind = NewInstantiationSyntaxKind.Prefix;
+        newProp.keyword = "new";
     }
 
     /**

--- a/src/Languages/Language.ts
+++ b/src/Languages/Language.ts
@@ -18,6 +18,7 @@ import { LanguageProperties } from "./Properties/LanguageProperties";
 import { ListProperties } from "./Properties/ListProperties";
 import { LoopProperties } from "./Properties/LoopProperties";
 import { MathProperties } from "./Properties/MathProperties";
+import { NewProperties } from "./Properties/NewProperties";
 import { NumberProperties } from "./Properties/NumberProperties";
 import { OperatorProperties } from "./Properties/OperatorProperties";
 import { OutputProperties } from "./Properties/OutputProperties";
@@ -60,6 +61,7 @@ export abstract class Language {
         this.generateListProperties(this.properties.lists);
         this.generateLoopProperties(this.properties.loops);
         this.generateMathProperties(this.properties.math);
+        this.generateNewProperties(this.properties.newProp);
         this.generateNumberProperties(this.properties.numbers);
         this.generateOperatorProperties(this.properties.operators);
         this.generateOutputProperties(this.properties.output);
@@ -200,6 +202,13 @@ export abstract class Language {
      * @param math   A property container for metadata on math.
      */
     protected abstract generateMathProperties(math: MathProperties): void;
+
+    /**
+     * Generates metadata on numbers.
+     * 
+     * @param numbers   A property container for metadata on numbers.
+     */
+    protected abstract generateNewProperties(newProp: NewProperties): void;
 
     /**
      * Generates metadata on numbers.

--- a/src/Languages/Language.ts
+++ b/src/Languages/Language.ts
@@ -204,6 +204,13 @@ export abstract class Language {
     protected abstract generateMathProperties(math: MathProperties): void;
 
     /**
+     * Generates metadata on newProp.
+     * 
+     * @param newProp   A property container for metadata on new object instantiation.
+     */
+    protected abstract generateNewProperties(newProp: NewProperties): void;
+
+    /**
      * Generates metadata on numbers.
      * 
      * @param numbers   A property container for metadata on numbers.

--- a/src/Languages/Properties/LanguageProperties.ts
+++ b/src/Languages/Properties/LanguageProperties.ts
@@ -15,6 +15,7 @@ import { LambdaProperties } from "./LambdaProperties";
 import { ListProperties } from "./ListProperties";
 import { LoopProperties } from "./LoopProperties";
 import { MathProperties } from "./MathProperties";
+import { NewProperties } from "./NewProperties";
 import { NumberProperties } from "./NumberProperties";
 import { OutputProperties } from "./OutputProperties";
 import { OperatorProperties } from "./OperatorProperties";
@@ -113,6 +114,11 @@ export class LanguageProperties {
     public math: MathProperties;
 
     /**
+     * Metadata on new object instantiations.
+     */
+    public newProp: NewProperties;
+
+    /**
      * Metadata on numbers.
      */
     public numbers: NumberProperties;
@@ -168,6 +174,7 @@ export class LanguageProperties {
         this.lists = new ListProperties();
         this.loops = new LoopProperties();
         this.math = new MathProperties();
+        this.newProp = new NewProperties();
         this.numbers = new NumberProperties();
         this.operators = new OperatorProperties();
         this.output = new OutputProperties();

--- a/src/Languages/Properties/NewProperties.ts
+++ b/src/Languages/Properties/NewProperties.ts
@@ -1,0 +1,34 @@
+/**
+ * What kind of syntactical form new object instantiations follow.
+ */
+export enum NewInstantiationSyntaxKind {
+    /**
+     * Called as a member of an array containing the parameters.
+     */
+    Prefix,
+
+    /**
+     * Called as a member of the calling object.
+     */
+    MethodCall,
+
+    /**
+     * Called as an operator on or with the calling object.
+     */
+    MemberMethodCall
+}
+
+/**
+ * Metadata on how to perform a native call, such as Array::push.
+ */
+export class NewProperties {
+    /**
+     * The keyword used to instantiate a new object.
+     */
+    public keyword: string;
+
+    /**
+     * What kind of syntactical form is used for new object instantiations.
+     */
+    public instantiationKind: NewInstantiationSyntaxKind;
+}

--- a/src/Languages/Python.ts
+++ b/src/Languages/Python.ts
@@ -18,6 +18,7 @@ import { ListProperties } from "./Properties/ListProperties";
 import { LoopProperties } from "./Properties/LoopProperties";
 import { MathProperties } from "./Properties/MathProperties";
 import { NativeCallProperties, NativeCallScope, NativeCallType } from "./Properties/NativeCallProperties";
+import { NewProperties, NewInstantiationSyntaxKind } from "./Properties/NewProperties";
 import { NumberProperties } from "./Properties/NumberProperties";
 import { OutputProperties } from "./Properties/OutputProperties";
 import { ParameterProperties } from "./Properties/ParameterProperties";
@@ -316,6 +317,15 @@ export class Python extends PythonicLanguage {
             NativeCallType.Function);
         math.requiredImports = [];
         math.mathName = "Math";
+    }
+
+    /**
+     * Generates metadata on new object instantiation.
+     * 
+     * @param numbers   A property container for metadata on numbers.
+     */
+    protected generateNewProperties(newProp: NewProperties): void {
+        newProp.instantiationKind = NewInstantiationSyntaxKind.MethodCall;
     }
 
     /**

--- a/src/Languages/Python.ts
+++ b/src/Languages/Python.ts
@@ -322,7 +322,7 @@ export class Python extends PythonicLanguage {
     /**
      * Generates metadata on new object instantiation.
      * 
-     * @param numbers   A property container for metadata on numbers.
+     * @param newProp   A property container for metadata on new object instantiation.
      */
     protected generateNewProperties(newProp: NewProperties): void {
         newProp.instantiationKind = NewInstantiationSyntaxKind.MethodCall;

--- a/src/Languages/Ruby.ts
+++ b/src/Languages/Ruby.ts
@@ -17,6 +17,7 @@ import { LambdaProperties } from "./Properties/LambdaProperties";
 import { ListProperties } from "./Properties/ListProperties";
 import { LoopProperties } from "./Properties/LoopProperties";
 import { MathProperties } from "./Properties/MathProperties";
+import { NewProperties, NewInstantiationSyntaxKind } from "./Properties/NewProperties";
 import { NativeCallProperties, NativeCallScope, NativeCallType } from "./Properties/NativeCallProperties";
 import { NumberProperties } from "./Properties/NumberProperties";
 import { OutputProperties } from "./Properties/OutputProperties";
@@ -325,6 +326,16 @@ export class Ruby extends PythonicLanguage {
             NativeCallType.Function);
         math.requiredImports = [];
         math.mathName = "Math";
+    }
+
+    /**
+     * Generates metadata on new object instantiation.
+     * 
+     * @param numbers   A property container for metadata on numbers.
+     */
+    protected generateNewProperties(newProp: NewProperties): void {
+        newProp.instantiationKind = NewInstantiationSyntaxKind.MemberMethodCall;
+        newProp.keyword = "new";
     }
 
     /**

--- a/src/Languages/Ruby.ts
+++ b/src/Languages/Ruby.ts
@@ -331,7 +331,7 @@ export class Ruby extends PythonicLanguage {
     /**
      * Generates metadata on new object instantiation.
      * 
-     * @param numbers   A property container for metadata on numbers.
+     * @param newProp   A property container for metadata on new object instantiation.
      */
     protected generateNewProperties(newProp: NewProperties): void {
         newProp.instantiationKind = NewInstantiationSyntaxKind.MemberMethodCall;

--- a/src/Languages/TypeScript.ts
+++ b/src/Languages/TypeScript.ts
@@ -349,7 +349,7 @@ export class TypeScript extends CLikeLanguage {
     /**
      * Generates metadata on new object instantiation.
      * 
-     * @param numbers   A property container for metadata on numbers.
+     * @param newProp   A property container for metadata on new object instantiation.
      */
     protected generateNewProperties(newProp: NewProperties): void {
         newProp.instantiationKind = NewInstantiationSyntaxKind.Prefix;

--- a/src/Languages/TypeScript.ts
+++ b/src/Languages/TypeScript.ts
@@ -18,6 +18,7 @@ import { LambdaProperties } from "./Properties/LambdaProperties";
 import { ListProperties } from "./Properties/ListProperties";
 import { LoopProperties } from "./Properties/LoopProperties";
 import { MathProperties } from "./Properties/MathProperties";
+import { NewProperties, NewInstantiationSyntaxKind } from "./Properties/NewProperties";
 import { NativeCallProperties, NativeCallScope, NativeCallType } from "./Properties/NativeCallProperties";
 import { NumberProperties } from "./Properties/NumberProperties";
 import { OperatorProperties } from "./Properties/OperatorProperties";
@@ -343,6 +344,16 @@ export class TypeScript extends CLikeLanguage {
             NativeCallType.Function);
         math.requiredImports = [];
         math.mathName = "Math";
+    }
+
+    /**
+     * Generates metadata on new object instantiation.
+     * 
+     * @param numbers   A property container for metadata on numbers.
+     */
+    protected generateNewProperties(newProp: NewProperties): void {
+        newProp.instantiationKind = NewInstantiationSyntaxKind.Prefix;
+        newProp.keyword = "new";
     }
 
     /**

--- a/test/integration/New/new no parameter.cs
+++ b/test/integration/New/new no parameter.cs
@@ -1,0 +1,3 @@
+-
+new ClassName()
+-

--- a/test/integration/New/new no parameter.gls
+++ b/test/integration/New/new no parameter.gls
@@ -1,0 +1,3 @@
+-
+new object : ClassName
+-

--- a/test/integration/New/new no parameter.gls
+++ b/test/integration/New/new no parameter.gls
@@ -1,3 +1,3 @@
 -
-new object : ClassName
+new : ClassName
 -

--- a/test/integration/New/new no parameter.java
+++ b/test/integration/New/new no parameter.java
@@ -1,0 +1,3 @@
+-
+new ClassName()
+-

--- a/test/integration/New/new no parameter.js
+++ b/test/integration/New/new no parameter.js
@@ -1,0 +1,3 @@
+-
+new ClassName()
+-

--- a/test/integration/New/new no parameter.py
+++ b/test/integration/New/new no parameter.py
@@ -1,0 +1,3 @@
+-
+ClassName()
+-

--- a/test/integration/New/new no parameter.rb
+++ b/test/integration/New/new no parameter.rb
@@ -1,0 +1,3 @@
+-
+ClassName.new()
+-

--- a/test/integration/New/new no parameter.ts
+++ b/test/integration/New/new no parameter.ts
@@ -1,0 +1,3 @@
+-
+new ClassName()
+-

--- a/test/integration/New/new single parameter.cs
+++ b/test/integration/New/new single parameter.cs
@@ -1,0 +1,3 @@
+-
+new ClassName(arg1)
+-

--- a/test/integration/New/new single parameter.gls
+++ b/test/integration/New/new single parameter.gls
@@ -1,3 +1,3 @@
 -
-new object : ClassName arg1
+new : ClassName arg1
 -

--- a/test/integration/New/new single parameter.gls
+++ b/test/integration/New/new single parameter.gls
@@ -1,0 +1,3 @@
+-
+new object : ClassName arg1
+-

--- a/test/integration/New/new single parameter.java
+++ b/test/integration/New/new single parameter.java
@@ -1,0 +1,3 @@
+-
+new ClassName(arg1)
+-

--- a/test/integration/New/new single parameter.js
+++ b/test/integration/New/new single parameter.js
@@ -1,0 +1,3 @@
+-
+new ClassName(arg1)
+-

--- a/test/integration/New/new single parameter.py
+++ b/test/integration/New/new single parameter.py
@@ -1,0 +1,3 @@
+-
+ClassName(arg1)
+-

--- a/test/integration/New/new single parameter.rb
+++ b/test/integration/New/new single parameter.rb
@@ -1,0 +1,3 @@
+-
+ClassName.new(arg1)
+-

--- a/test/integration/New/new single parameter.ts
+++ b/test/integration/New/new single parameter.ts
@@ -1,0 +1,3 @@
+-
+new ClassName(arg1)
+-

--- a/test/integration/New/new two parameters.cs
+++ b/test/integration/New/new two parameters.cs
@@ -1,0 +1,3 @@
+-
+new ClassName(arg1, arg2)
+-

--- a/test/integration/New/new two parameters.gls
+++ b/test/integration/New/new two parameters.gls
@@ -1,3 +1,3 @@
 -
-new object : ClassName arg1 arg2
+new : ClassName arg1 arg2
 -

--- a/test/integration/New/new two parameters.gls
+++ b/test/integration/New/new two parameters.gls
@@ -1,0 +1,3 @@
+-
+new object : ClassName arg1 arg2
+-

--- a/test/integration/New/new two parameters.java
+++ b/test/integration/New/new two parameters.java
@@ -1,0 +1,3 @@
+-
+new ClassName(arg1, arg2)
+-

--- a/test/integration/New/new two parameters.js
+++ b/test/integration/New/new two parameters.js
@@ -1,0 +1,3 @@
+-
+new ClassName(arg1, arg2)
+-

--- a/test/integration/New/new two parameters.py
+++ b/test/integration/New/new two parameters.py
@@ -1,0 +1,3 @@
+-
+ClassName(arg1, arg2)
+-

--- a/test/integration/New/new two parameters.rb
+++ b/test/integration/New/new two parameters.rb
@@ -1,0 +1,3 @@
+-
+ClassName.new(arg1, arg2)
+-

--- a/test/integration/New/new two parameters.ts
+++ b/test/integration/New/new two parameters.ts
@@ -1,0 +1,3 @@
+-
+new ClassName(arg1, arg2)
+-


### PR DESCRIPTION
add support for instantiation of new objects

GLS syntax:
`new: <TypeName> [<ConstructorArgument>*]`

fixes #215 